### PR TITLE
fix: add hilbish to /etc/shells

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,14 @@ install:
 	@install -v -d "$(BINDIR)/" && install -m 0755 -v hilbish "$(BINDIR)/hilbish"
 	@mkdir -p "$(LIBDIR)"
 	@cp libs preload.lua .hilbishrc.lua "$(LIBDIR)" -r
+	@echo /usr/bin/hilbish >> /etc/shells
 	@echo "Hilbish Installed"
 
 uninstall:
 	@rm -vrf \
 			"$(BINDIR)/hilbish" \
 			"$(LIBDIR)"
+	@sed '/\/usr\/bin\/hilbish/d' /etc/shells
 	@echo "Hilbish Uninstalled"
 
 clean:


### PR DESCRIPTION
Adds /usr/bin/hilbish to /etc/shells so that chsh doesn’t complain about it. Never worked with Makefiles before so I would test the appending and removal before merging. Maybe @JavaCafe01 could review too? 