### PR TITLE
fix: only create default config file if it doesn’t exist

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,12 +59,14 @@ func main() {
 	}
 
 	homedir, _ := os.UserHomeDir()
-	err = os.WriteFile(homedir + "/.hilbishrc.lua", input, 0644)
-	if err != nil {
-		fmt.Println("Error creating config file")
-		fmt.Println(err)
-		return
-        }
+	if _, err := os.Stat(homedir + "/.hilbishrc.lua"); os.IsNotExist(err) {
+		err = os.WriteFile(homedir + "/.hilbishrc.lua", input, 0644)
+		if err != nil {
+			fmt.Println("Error creating config file")
+			fmt.Println(err)
+			return
+		}
+	}
 
 	HandleSignals()
 	LuaInit()


### PR DESCRIPTION
Fixes #8. Never used go so it might not be the most idiomatic way of handling things. Doesn’t do any fancy stuff like configure error handling or reverting to the default on error.