### PR TITLE
feat: Add command.exit signal to bait

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,6 +108,7 @@ func main() {
 		if err == nil {
 			// If it succeeds, add to history and prompt again
 			readline.AddHistory(cmdString)
+			bait.Em.Emit("command.exit", nil)
 			bait.Em.Emit("command.success", nil)
 			continue
 		}
@@ -162,12 +163,14 @@ func main() {
 				} else {
 					if code, ok := interp.IsExitStatus(err); ok {
 						if code > 0 {
+							bait.Em.Emit("command.exit", nil)
 							bait.Em.Emit("command.fail", code)
 						}
 					}
 					fmt.Fprintln(os.Stderr, err)
 				}
 			} else {
+				bait.Em.Emit("command.exit", nil)
 				bait.Em.Emit("command.success", nil)
 			}
 		}


### PR DESCRIPTION
Adds a `command.exit` signal to bait that is fired both when a command succeeds and when it fails.