### PR TITLE
feat: Add command.exit signal to bait

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -24,6 +24,7 @@ func RunInput(input string) {
 		// If it succeeds, add to history and prompt again
 		readline.AddHistory(input)
 		readline.SaveHistory(homedir + "/.hilbish-history")
+		bait.Em.Emit("command.exit", nil)
 		bait.Em.Emit("command.success", nil)
 		return
 	}
@@ -79,12 +80,14 @@ func RunInput(input string) {
 			} else {
 				if code, ok := interp.IsExitStatus(err); ok {
 					if code > 0 {
+						bait.Em.Emit("command.exit", nil)
 						bait.Em.Emit("command.fail", code)
 					}
 				}
 				fmt.Fprintln(os.Stderr, err)
 			}
 		} else {
+			bait.Em.Emit("command.exit", nil)
 			bait.Em.Emit("command.success", nil)
 		}
 	}


### PR DESCRIPTION
Finally.

This adds the `command.exit`  signal to bait, which is emitted both when a command succeeds or fails.

Bottom text.