### PR TITLE
fix: makefile login shell file fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ install:
 	@install -v -d "$(DESTDIR)$(BINDIR)/" && install -m 0755 -v hilbish "$(DESTDIR)$(BINDIR)/hilbish"
 	@mkdir -p "$(DESTDIR)$(LIBDIR)"
 	@cp libs preload.lua .hilbishrc.lua "$(DESTDIR)$(LIBDIR)" -r
-	@grep "$(DESTDIR)$(BINDIR)/hilbish" -qxF  /etc/shells || echo "$(DESTDIR)$(BINDIR)/hilbish" >> /etc/shells
+	@grep "$(DESTDIR)$(BINDIR)/hilbish" -qxF /etc/shells || echo "$(DESTDIR)$(BINDIR)/hilbish" >> /etc/shells
 	@echo "Hilbish Installed"
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ install:
 	@install -v -d "$(DESTDIR)$(BINDIR)/" && install -m 0755 -v hilbish "$(DESTDIR)$(BINDIR)/hilbish"
 	@mkdir -p "$(DESTDIR)$(LIBDIR)"
 	@cp libs preload.lua .hilbishrc.lua "$(DESTDIR)$(LIBDIR)" -r
-	@echo "$(DESTDIR)$(BINDIR)/hilbish" >> /etc/shells
+	@grep "$(DESTDIR)$(BINDIR)/hilbish" -qxF  /etc/shells || echo "$(DESTDIR)$(BINDIR)/hilbish" >> /etc/shells
 	@echo "Hilbish Installed"
 
 uninstall:


### PR DESCRIPTION
This fixes the problem where installing kept adding hilbish to
`/etc/shells` even if it was already there.

---
- [x] I have reviewed CONTRIBUTING.md.
- [x] My commits and title use the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] I have documented any breaking changes according to [SemVer](https://semver.org/).
---
